### PR TITLE
ForensicError implements `std::error::Error` by using thiserror::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde = ["dep:serde"]
 
 [dependencies]
 serde = {version = "1", optional = true}
+thiserror = "1"
 
 [dev-dependencies]
 sqlite = "0.28.1"


### PR DESCRIPTION
Every error should implement `std::error::Error`. For simple conversion, `thiserror` can be used.

If you do not like having an additional dependency, `std::error::Error` needs to be implemented manually