### PR TITLE
add macos support

### DIFF
--- a/src/core/fs/stdfs.rs
+++ b/src/core/fs/stdfs.rs
@@ -87,7 +87,7 @@ impl VirtualFileSystem for StdVirtualFS {
     fn read_all(&mut self, path: &Path) -> ForensicResult<Vec<u8>> {
         Ok(std::fs::read(path)?)
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(not(target_os = "windows"))]
     fn read(&mut self, path: &Path, pos: u64, buf: &mut [u8]) -> ForensicResult<usize> {
         use std::os::unix::prelude::FileExt;
         let file = std::fs::File::open(path)?;


### PR DESCRIPTION
I am not sure if this is the best way to support Mac builds but this works so far in testing with a small wrapper application I am using. I wanted to be able to build the wrapper application on Linux, Mac or Windows depending on the users needs.